### PR TITLE
Corrected link to Device Art Generator (fixes 404 issue)

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -58,7 +58,7 @@
         <h2 id="group-misc">Other generators <span>&mdash; Miscellaneous asset creation tools</span></h2>
         <ul>
           <li><a href="nine-patches.html">Simple nine-patch generator</a></li>
-          <li><a href="http://developer.android.com/distribute/promote/device-art.html">Official Android Device Art Generator</a></li>
+          <li><a href="http://developer.android.com/distribute/tools/promote/device-art.html">Official Android Device Art Generator</a></li>
         </ul>
 
         <h2 id="group-community">Community tools <span>&mdash; Similar tools from the open source community</span></h2>


### PR DESCRIPTION
Goto http://romannurik.github.io/AndroidAssetStudio/

Click the link "Official Android Device Art Generator"

Get's a 404 going to:
http://developer.android.com/distribute/promote/device-art.html

needs to go to:

http://developer.android.com/distribute/tools/promote/device-art.html
