### PR TITLE
Update clipart source link and color field palette

### DIFF
--- a/src/js/src/studio/fields.js
+++ b/src/js/src/studio/fields.js
@@ -220,12 +220,16 @@ studio.forms.ColorField = studio.forms.Field.extend({
       showInput: true,
       showPalette: true,
       palette: [
-        ['#fff', '#000'],
-        ['#33b5e5', '#09c'],
-        ['#a6c', '#93c'],
-        ['#9c0', '#690'],
-        ['#fb3', '#f80'],
-        ['#f44', '#c00']
+        ['#ffffff', '#000000'],
+        ['#f44336', '#e91e63'],
+        ['#9c27b0', '#673ab7'],
+        ['#3f51b5', '#2196f3'],
+        ['#03a9f4', '#00bcd4'],
+        ['#009688', '#4caf50'],
+        ['#8bc34a', '#cddc39'],
+        ['#ffeb3b', '#ffc107'],
+        ['#ff9800', '#ff5722'],
+        ['#9e9e9e', '#607d8b']
       ],
       localStorageKey: 'recentcolors',
       showInitial: true,

--- a/src/js/src/studio/imagefield.js
+++ b/src/js/src/studio/imagefield.js
@@ -181,8 +181,8 @@ studio.forms.ImageField = studio.forms.Field.extend({
         .addClass('form-image-clipart-attribution')
         .html([
             'For clipart sources, visit ',
-            '<a href="http://developer.android.com/design/downloads/">',
-                'Android Design: Downloads',
+            '<a href="https://github.com/google/material-design-icons">',
+                'Material Design Icons on GitHub',
             '</a>.<br>',
             'Additional icons can be found at ',
             '<a href="http://www.androidicons.com">androidicons.com</a>.'
@@ -333,7 +333,7 @@ studio.forms.ImageField = studio.forms.Field.extend({
 
     $('img.form-image-clipart-item', this.el_.parent()).removeClass('selected');
     $('img[src="' + clipartSrc + '"]').addClass('selected');
-    
+
     this.imageParams_ = {
       isSvg: isSvg,
       canvgSvgUri: useCanvg ? clipartSrc : null,
@@ -947,7 +947,6 @@ studio.forms.ImageField.clipartList_ = [
 'icons/file_folder.svg',
 'icons/file_folder_open.svg',
 'icons/file_folder_shared.svg',
-'icons/foo',
 'icons/hardware_cast.svg',
 'icons/hardware_cast_connected.svg',
 'icons/hardware_computer.svg',


### PR DESCRIPTION
This change updates the link for clipart sources to point to the Material Design Icons GitHub project, removes an invalid "foo" item from the clipart list, and changes the color field default palette to use the material design primary colors.