### PR TITLE
Change res foldernames back to drawable-*

### DIFF
--- a/src/html/icons-launcher.html
+++ b/src/html/icons-launcher.html
@@ -379,7 +379,7 @@
             zipper.add({
               name: (density == 'web') ?
                   ('web_hi_res_512.png') :
-                  ('res/mipmap-' + density + '/ic_launcher.png'),
+                  ('res/drawable-' + density + '/ic_launcher.png'),
               base64data: outCtx.canvas.toDataURL().match(/;base64,(.+)/)[1]
             });
 


### PR DESCRIPTION
I don't know if @jgilfelt had a reason to change the name of the drawable folder, but if not I'd sugget to keep it as drawable-*. This makes it easier to just throw all the folders in to an apps res folder.