### PR TITLE
Update launcher icons generator with elevation support

### DIFF
--- a/src/html/icons-launcher.html
+++ b/src/html/icons-launcher.html
@@ -319,6 +319,8 @@
               tmpCtx.fillStyle = values['backColor'].color;
               tmpCtx.fillRect(0, 0, iconSize.w, iconSize.h);
 
+              var shadowIntensity = values['shadowIntensity'];
+
               if (foreCtx) {
                 var tmpCtx2 = imagelib.drawing.context(iconSize);
                 tmpCtx2.save();
@@ -349,7 +351,7 @@
                       x: 0, y: 0,
                       w: foreSize.w, h: foreSize.h
                     });
-                  imagelib.effects.renderLongShadow(tmpCtx4, iconSize.w, iconSize.h);
+                  imagelib.effects.renderLongShadow(tmpCtx4, iconSize.w, iconSize.h, shadowIntensity);
                   imagelib.drawing.copy(tmpCtx2, tmpCtx4, iconSize);
                 }
 
@@ -360,7 +362,7 @@
                       x: 0, y: 0,
                       w: foreSize.w, h: foreSize.h
                     });
-                  imagelib.effects.renderDropShadow(tmpCtx6, iconSize.w, iconSize.h);
+                  imagelib.effects.renderDropShadow(tmpCtx6, iconSize.w, iconSize.h, shadowIntensity);
                   imagelib.drawing.copy(tmpCtx2, tmpCtx6, iconSize);
 								}
 
@@ -374,7 +376,7 @@
 
                 if (values['effects'] == 'score') {
                   var tmpCtx5 = imagelib.drawing.context(iconSize);
-                  imagelib.effects.renderScore(tmpCtx5, iconSize.w, iconSize.h);
+                  imagelib.effects.renderScore(tmpCtx5, iconSize.w, iconSize.h, shadowIntensity);
                   imagelib.drawing.copy(tmpCtx, tmpCtx5, iconSize);
                 }
 
@@ -465,6 +467,14 @@
             defaultValue: false,
             offText: 'Off',
             onText: 'On'
+          }), new studio.forms.RangeField('shadowIntensity', {
+            title: 'Shadow Intensity',
+            helpText: 'For elevation, score, and long shadow',
+            min: 0,
+            max: 100,
+            step: 5,
+            showText: true,
+            defaultValue: 50
           })
           // new studio.forms.EnumField('recenter', {
           //   title: 'Recentering',

--- a/src/html/icons-launcher.html
+++ b/src/html/icons-launcher.html
@@ -353,6 +353,17 @@
                   imagelib.drawing.copy(tmpCtx2, tmpCtx4, iconSize);
                 }
 
+								if(values['elevation']){
+									var tmpCtx6 = imagelib.drawing.context(iconSize);
+                  imagelib.drawing[values['crop'] ? 'drawCenterCrop' : 'drawCenterInside']
+                    (tmpCtx6, copyFrom, targetRect, {
+                      x: 0, y: 0,
+                      w: foreSize.w, h: foreSize.h
+                    });
+                  imagelib.effects.renderDropShadow(tmpCtx6, iconSize.w, iconSize.h);
+                  imagelib.drawing.copy(tmpCtx2, tmpCtx6, iconSize);
+								}
+
                 imagelib.drawing[values['crop'] ? 'drawCenterCrop' : 'drawCenterInside']
                   (tmpCtx2, copyFrom, targetRect, {
                     x: 0, y: 0,
@@ -448,6 +459,12 @@
               { id: 'dogear', title: 'Dog-Ear' }
             ],
             defaultValue: 'none'
+          }),
+					new studio.forms.BooleanField('elevation', {
+            title: 'Elevation',
+            defaultValue: false,
+            offText: 'Off',
+            onText: 'On'
           })
           // new studio.forms.EnumField('recenter', {
           //   title: 'Recentering',

--- a/src/html/icons-launcher.html
+++ b/src/html/icons-launcher.html
@@ -355,8 +355,8 @@
                   imagelib.drawing.copy(tmpCtx2, tmpCtx4, iconSize);
                 }
 
-								if(values['elevation']){
-									var tmpCtx6 = imagelib.drawing.context(iconSize);
+                if(values['elevation']){
+                  var tmpCtx6 = imagelib.drawing.context(iconSize);
                   imagelib.drawing[values['crop'] ? 'drawCenterCrop' : 'drawCenterInside']
                     (tmpCtx6, copyFrom, targetRect, {
                       x: 0, y: 0,
@@ -364,7 +364,7 @@
                     });
                   imagelib.effects.renderDropShadow(tmpCtx6, iconSize.w, iconSize.h, shadowIntensity);
                   imagelib.drawing.copy(tmpCtx2, tmpCtx6, iconSize);
-								}
+                }
 
                 imagelib.drawing[values['crop'] ? 'drawCenterCrop' : 'drawCenterInside']
                   (tmpCtx2, copyFrom, targetRect, {
@@ -462,7 +462,7 @@
             ],
             defaultValue: 'none'
           }),
-					new studio.forms.BooleanField('elevation', {
+          new studio.forms.BooleanField('elevation', {
             title: 'Elevation',
             defaultValue: false,
             offText: 'Off',

--- a/src/js/src/imagelib/effects.js
+++ b/src/js/src/imagelib/effects.js
@@ -86,12 +86,14 @@ imagelib.effects.isUnderImage = function(imgData, x, y) {
 
 imagelib.effects.castShade = function(imgData, x, y, shade) {
   var n = shade;
-  var step = n / (imgData.width + imgData.height);
-  var alpha = n - ((x + y) * step);
+  // Old linear shade casting
+  //var step = n / (imgData.width + imgData.height);
+  //var alpha = n - ((x + y) * step);
+  
   // Alternate radial shade casting
-  //var step = n / (Math.sqrt(Math.pow(imgData.width, 2) + Math.pow(imgData.height, 2)));
-  //var dist = Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2));
-  //var alpha = n - ((dist) * step);
+  var step = n / (Math.sqrt(Math.pow(imgData.width, 2) + Math.pow(imgData.height, 2)));
+  var dist = Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2));
+  var alpha = n - ((dist) * step);
   var color = [0, 0, 0, alpha];
   //if (imgData.width == 48) console.log('shade alpha = ' + alpha + ' for ' + x + ',' + y);
   return imagelib.effects.setColor(imgData, x, y, color);

--- a/src/js/src/imagelib/effects.js
+++ b/src/js/src/imagelib/effects.js
@@ -15,11 +15,13 @@ limitations under the License.
 */
 
 //#REQUIRE "includes.js"
+//#REQUIRE "stackblur.js"
 
 imagelib.effects = {};
 
 imagelib.effects.renderLongShadow = function(ctx, w, h) {
   var imgData = ctx.getImageData(0, 0, w, h);
+
   for(var y = 0; y < imgData.height; y++) {
     for(var x = 0; x < imgData.width; x++) {
       if (imagelib.effects.isInShade(imgData, x, y)) {
@@ -29,6 +31,25 @@ imagelib.effects.renderLongShadow = function(ctx, w, h) {
   }
   ctx.putImageData(imgData, 0, 0);
 };
+
+imagelib.effects.renderDropShadow = function(ctx, w, h) {
+	var imgData = ctx.getImageData(0, 0, w, h);
+  for(var y = 0; y < imgData.height; y++) {
+    for(var x = 0; x < imgData.width; x++) {
+      if (imagelib.effects.isUnderImage(imgData, x, y)) {
+				var color = [0, 0, 0, 50];
+        // Change the image color to semi-transparent black for the shadow
+        // Opacity of 20% per material design guidelines
+      	imagelib.effects.setColor(imgData, x, y, color);
+      }
+    }
+  }
+  ctx.putImageData(imgData, 0, 0);
+  // Blur amount must be multiple of size to accommodate different icon sizes
+	var blurRadius = w / 20;
+  // Blur the shadow
+	stackBlurImage(ctx, blurRadius, w, h);
+}
 
 imagelib.effects.renderScore = function(ctx, w, h) {
   var imgData = ctx.getImageData(0, 0, w, h);
@@ -58,10 +79,20 @@ imagelib.effects.isInShade = function(imgData, x, y) {
   }
 };
 
+imagelib.effects.isUnderImage = function(imgData, x, y) {
+  var data = imgData.data;
+	return imagelib.effects.getAlpha(imgData, x, y);
+};
+
 imagelib.effects.castShade = function(imgData, x, y) {
-  var n = 32;
+  // Material recommended opacity of 20%
+  var n = 50;
   var step = n / (imgData.width + imgData.height);
   var alpha = n - ((x + y) * step);
+  // Alternate radial shade casting
+  //var step = n / (Math.sqrt(Math.pow(imgData.width, 2) + Math.pow(imgData.height, 2)));
+  //var dist = Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2));
+  //var alpha = n - ((dist) * step);
   var color = [0, 0, 0, alpha];
   //if (imgData.width == 48) console.log('shade alpha = ' + alpha + ' for ' + x + ',' + y);
   return imagelib.effects.setColor(imgData, x, y, color);

--- a/src/js/src/imagelib/effects.js
+++ b/src/js/src/imagelib/effects.js
@@ -33,21 +33,21 @@ imagelib.effects.renderLongShadow = function(ctx, w, h, shade) {
 };
 
 imagelib.effects.renderDropShadow = function(ctx, w, h, shade) {
-	var imgData = ctx.getImageData(0, 0, w, h);
+  var imgData = ctx.getImageData(0, 0, w, h);
   for(var y = 0; y < imgData.height; y++) {
     for(var x = 0; x < imgData.width; x++) {
       if (imagelib.effects.isUnderImage(imgData, x, y)) {
-				var color = [0, 0, 0, shade];
+        var color = [0, 0, 0, shade];
         // Change the image color to semi-transparent black for the shadow
-      	imagelib.effects.setColor(imgData, x, y, color);
+        imagelib.effects.setColor(imgData, x, y, color);
       }
     }
   }
   ctx.putImageData(imgData, 0, 0);
   // Blur amount must be multiple of size to accommodate different icon sizes
-	var blurRadius = w / 20;
+  var blurRadius = w / 20;
   // Blur the shadow
-	stackBlurImage(ctx, blurRadius, w, h);
+  stackBlurImage(ctx, blurRadius, w, h);
 }
 
 imagelib.effects.renderScore = function(ctx, w, h, shade) {
@@ -81,7 +81,7 @@ imagelib.effects.isInShade = function(imgData, x, y) {
 
 imagelib.effects.isUnderImage = function(imgData, x, y) {
   var data = imgData.data;
-	return imagelib.effects.getAlpha(imgData, x, y);
+  return imagelib.effects.getAlpha(imgData, x, y);
 };
 
 imagelib.effects.castShade = function(imgData, x, y, shade) {

--- a/src/js/src/imagelib/effects.js
+++ b/src/js/src/imagelib/effects.js
@@ -19,27 +19,26 @@ limitations under the License.
 
 imagelib.effects = {};
 
-imagelib.effects.renderLongShadow = function(ctx, w, h) {
+imagelib.effects.renderLongShadow = function(ctx, w, h, shade) {
   var imgData = ctx.getImageData(0, 0, w, h);
 
   for(var y = 0; y < imgData.height; y++) {
     for(var x = 0; x < imgData.width; x++) {
       if (imagelib.effects.isInShade(imgData, x, y)) {
-        imagelib.effects.castShade(imgData, x, y);
+        imagelib.effects.castShade(imgData, x, y, shade);
       }
     }
   }
   ctx.putImageData(imgData, 0, 0);
 };
 
-imagelib.effects.renderDropShadow = function(ctx, w, h) {
+imagelib.effects.renderDropShadow = function(ctx, w, h, shade) {
 	var imgData = ctx.getImageData(0, 0, w, h);
   for(var y = 0; y < imgData.height; y++) {
     for(var x = 0; x < imgData.width; x++) {
       if (imagelib.effects.isUnderImage(imgData, x, y)) {
-				var color = [0, 0, 0, 50];
+				var color = [0, 0, 0, shade];
         // Change the image color to semi-transparent black for the shadow
-        // Opacity of 20% per material design guidelines
       	imagelib.effects.setColor(imgData, x, y, color);
       }
     }
@@ -51,11 +50,12 @@ imagelib.effects.renderDropShadow = function(ctx, w, h) {
 	stackBlurImage(ctx, blurRadius, w, h);
 }
 
-imagelib.effects.renderScore = function(ctx, w, h) {
+imagelib.effects.renderScore = function(ctx, w, h, shade) {
+  var scoreShade = shade / 2;
   var imgData = ctx.getImageData(0, 0, w, h);
   for(var y = 0; y < imgData.height/2; y++) {
     for(var x = 0; x < imgData.width; x++) {
-      var color = [0, 0, 0, 24];
+      var color = [0, 0, 0, scoreShade];
       imagelib.effects.setColor(imgData, x, y, color);
     }
   }
@@ -84,9 +84,8 @@ imagelib.effects.isUnderImage = function(imgData, x, y) {
 	return imagelib.effects.getAlpha(imgData, x, y);
 };
 
-imagelib.effects.castShade = function(imgData, x, y) {
-  // Material recommended opacity of 20%
-  var n = 50;
+imagelib.effects.castShade = function(imgData, x, y, shade) {
+  var n = shade;
   var step = n / (imgData.width + imgData.height);
   var alpha = n - ((x + y) * step);
   // Alternate radial shade casting

--- a/src/js/src/imagelib/stackblur.js
+++ b/src/js/src/imagelib/stackblur.js
@@ -1,0 +1,323 @@
+/*
+Copyright (c) 2010 Mario Klingemann
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+var mul_table = [
+  512, 512, 456, 512, 328, 456, 335, 512, 405, 328, 271, 456, 388, 335, 292, 512,
+  454, 405, 364, 328, 298, 271, 496, 456, 420, 388, 360, 335, 312, 292, 273, 512,
+  482, 454, 428, 405, 383, 364, 345, 328, 312, 298, 284, 271, 259, 496, 475, 456,
+  437, 420, 404, 388, 374, 360, 347, 335, 323, 312, 302, 292, 282, 273, 265, 512,
+  497, 482, 468, 454, 441, 428, 417, 405, 394, 383, 373, 364, 354, 345, 337, 328,
+  320, 312, 305, 298, 291, 284, 278, 271, 265, 259, 507, 496, 485, 475, 465, 456,
+  446, 437, 428, 420, 412, 404, 396, 388, 381, 374, 367, 360, 354, 347, 341, 335,
+  329, 323, 318, 312, 307, 302, 297, 292, 287, 282, 278, 273, 269, 265, 261, 512,
+  505, 497, 489, 482, 475, 468, 461, 454, 447, 441, 435, 428, 422, 417, 411, 405,
+  399, 394, 389, 383, 378, 373, 368, 364, 359, 354, 350, 345, 341, 337, 332, 328,
+  324, 320, 316, 312, 309, 305, 301, 298, 294, 291, 287, 284, 281, 278, 274, 271,
+  268, 265, 262, 259, 257, 507, 501, 496, 491, 485, 480, 475, 470, 465, 460, 456,
+  451, 446, 442, 437, 433, 428, 424, 420, 416, 412, 408, 404, 400, 396, 392, 388,
+  385, 381, 377, 374, 370, 367, 363, 360, 357, 354, 350, 347, 344, 341, 338, 335,
+  332, 329, 326, 323, 320, 318, 315, 312, 310, 307, 304, 302, 299, 297, 294, 292,
+  289, 287, 285, 282, 280, 278, 275, 273, 271, 269, 267, 265, 263, 261, 259
+];
+
+var shg_table = [
+  9, 11, 12, 13, 13, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16, 17,
+  17, 17, 17, 17, 17, 17, 18, 18, 18, 18, 18, 18, 18, 18, 18, 19,
+  19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 20, 20, 20,
+  20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 21,
+  21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
+  21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 22, 22, 22, 22, 22, 22,
+  22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22,
+  22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 23,
+  23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23,
+  23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23,
+  23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23,
+  23, 23, 23, 23, 23, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+  24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+  24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+  24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+  24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24
+];
+
+function stackBlurImage(context, radius, w, h) {
+  if (isNaN(radius) || radius < 1) return;
+  stackBlurCanvasRGBA(context, 0, 0, w, h, radius);
+}
+
+function stackBlurCanvasRGBA(context, top_x, top_y, width, height, radius) {
+  if (isNaN(radius) || radius < 1) return;
+  radius |= 0;
+
+  var imageData;
+
+  try {
+    try {
+      imageData = context.getImageData(top_x, top_y, width, height);
+    } catch (e) {
+
+      // NOTE: this part is supposedly only needed if you want to work with local files
+      // so it might be okay to remove the whole try/catch block and just use
+      // imageData = context.getImageData( top_x, top_y, width, height );
+      try {
+        netscape.security.PrivilegeManager.enablePrivilege("UniversalBrowserRead");
+        imageData = context.getImageData(top_x, top_y, width, height);
+      } catch (e) {
+        alert("Cannot access local image");
+        throw new Error("unable to access local image data: " + e);
+        return;
+      }
+    }
+  } catch (e) {
+    alert("Cannot access image");
+    throw new Error("unable to access image data: " + e);
+  }
+
+  var pixels = imageData.data;
+
+  var x, y, i, p, yp, yi, yw, r_sum, g_sum, b_sum, a_sum,
+    r_out_sum, g_out_sum, b_out_sum, a_out_sum,
+    r_in_sum, g_in_sum, b_in_sum, a_in_sum,
+    pr, pg, pb, pa, rbs;
+
+  var div = radius + radius + 1;
+  var w4 = width << 2;
+  var widthMinus1 = width - 1;
+  var heightMinus1 = height - 1;
+  var radiusPlus1 = radius + 1;
+  var sumFactor = radiusPlus1 * (radiusPlus1 + 1) / 2;
+
+  var stackStart = new BlurStack();
+  var stack = stackStart;
+  for (i = 1; i < div; i++) {
+    stack = stack.next = new BlurStack();
+    if (i == radiusPlus1) var stackEnd = stack;
+  }
+  stack.next = stackStart;
+  var stackIn = null;
+  var stackOut = null;
+
+  yw = yi = 0;
+
+  var mul_sum = mul_table[radius];
+  var shg_sum = shg_table[radius];
+
+  for (y = 0; y < height; y++) {
+    r_in_sum = g_in_sum = b_in_sum = a_in_sum = r_sum = g_sum = b_sum = a_sum = 0;
+
+    r_out_sum = radiusPlus1 * (pr = pixels[yi]);
+    g_out_sum = radiusPlus1 * (pg = pixels[yi + 1]);
+    b_out_sum = radiusPlus1 * (pb = pixels[yi + 2]);
+    a_out_sum = radiusPlus1 * (pa = pixels[yi + 3]);
+
+    r_sum += sumFactor * pr;
+    g_sum += sumFactor * pg;
+    b_sum += sumFactor * pb;
+    a_sum += sumFactor * pa;
+
+    stack = stackStart;
+
+    for (i = 0; i < radiusPlus1; i++) {
+      stack.r = pr;
+      stack.g = pg;
+      stack.b = pb;
+      stack.a = pa;
+      stack = stack.next;
+    }
+
+    for (i = 1; i < radiusPlus1; i++) {
+      p = yi + ((widthMinus1 < i ? widthMinus1 : i) << 2);
+      r_sum += (stack.r = (pr = pixels[p])) * (rbs = radiusPlus1 - i);
+      g_sum += (stack.g = (pg = pixels[p + 1])) * rbs;
+      b_sum += (stack.b = (pb = pixels[p + 2])) * rbs;
+      a_sum += (stack.a = (pa = pixels[p + 3])) * rbs;
+
+      r_in_sum += pr;
+      g_in_sum += pg;
+      b_in_sum += pb;
+      a_in_sum += pa;
+
+      stack = stack.next;
+    }
+
+    stackIn = stackStart;
+    stackOut = stackEnd;
+    for (x = 0; x < width; x++) {
+      pixels[yi + 3] = pa = (a_sum * mul_sum) >> shg_sum;
+      if (pa != 0) {
+        pa = 255 / pa;
+        pixels[yi] = ((r_sum * mul_sum) >> shg_sum) * pa;
+        pixels[yi + 1] = ((g_sum * mul_sum) >> shg_sum) * pa;
+        pixels[yi + 2] = ((b_sum * mul_sum) >> shg_sum) * pa;
+      } else {
+        pixels[yi] = pixels[yi + 1] = pixels[yi + 2] = 0;
+      }
+
+      r_sum -= r_out_sum;
+      g_sum -= g_out_sum;
+      b_sum -= b_out_sum;
+      a_sum -= a_out_sum;
+
+      r_out_sum -= stackIn.r;
+      g_out_sum -= stackIn.g;
+      b_out_sum -= stackIn.b;
+      a_out_sum -= stackIn.a;
+
+      p = (yw + ((p = x + radius + 1) < widthMinus1 ? p : widthMinus1)) << 2;
+
+      r_in_sum += (stackIn.r = pixels[p]);
+      g_in_sum += (stackIn.g = pixels[p + 1]);
+      b_in_sum += (stackIn.b = pixels[p + 2]);
+      a_in_sum += (stackIn.a = pixels[p + 3]);
+
+      r_sum += r_in_sum;
+      g_sum += g_in_sum;
+      b_sum += b_in_sum;
+      a_sum += a_in_sum;
+
+      stackIn = stackIn.next;
+
+      r_out_sum += (pr = stackOut.r);
+      g_out_sum += (pg = stackOut.g);
+      b_out_sum += (pb = stackOut.b);
+      a_out_sum += (pa = stackOut.a);
+
+      r_in_sum -= pr;
+      g_in_sum -= pg;
+      b_in_sum -= pb;
+      a_in_sum -= pa;
+
+      stackOut = stackOut.next;
+
+      yi += 4;
+    }
+    yw += width;
+  }
+
+  for (x = 0; x < width; x++) {
+    g_in_sum = b_in_sum = a_in_sum = r_in_sum = g_sum = b_sum = a_sum = r_sum = 0;
+
+    yi = x << 2;
+    r_out_sum = radiusPlus1 * (pr = pixels[yi]);
+    g_out_sum = radiusPlus1 * (pg = pixels[yi + 1]);
+    b_out_sum = radiusPlus1 * (pb = pixels[yi + 2]);
+    a_out_sum = radiusPlus1 * (pa = pixels[yi + 3]);
+
+    r_sum += sumFactor * pr;
+    g_sum += sumFactor * pg;
+    b_sum += sumFactor * pb;
+    a_sum += sumFactor * pa;
+
+    stack = stackStart;
+
+    for (i = 0; i < radiusPlus1; i++) {
+      stack.r = pr;
+      stack.g = pg;
+      stack.b = pb;
+      stack.a = pa;
+      stack = stack.next;
+    }
+
+    yp = width;
+
+    for (i = 1; i <= radius; i++) {
+      yi = (yp + x) << 2;
+
+      r_sum += (stack.r = (pr = pixels[yi])) * (rbs = radiusPlus1 - i);
+      g_sum += (stack.g = (pg = pixels[yi + 1])) * rbs;
+      b_sum += (stack.b = (pb = pixels[yi + 2])) * rbs;
+      a_sum += (stack.a = (pa = pixels[yi + 3])) * rbs;
+
+      r_in_sum += pr;
+      g_in_sum += pg;
+      b_in_sum += pb;
+      a_in_sum += pa;
+
+      stack = stack.next;
+
+      if (i < heightMinus1) {
+        yp += width;
+      }
+    }
+
+    yi = x;
+    stackIn = stackStart;
+    stackOut = stackEnd;
+    for (y = 0; y < height; y++) {
+      p = yi << 2;
+      pixels[p + 3] = pa = (a_sum * mul_sum) >> shg_sum;
+      if (pa > 0) {
+        pa = 255 / pa;
+        pixels[p] = ((r_sum * mul_sum) >> shg_sum) * pa;
+        pixels[p + 1] = ((g_sum * mul_sum) >> shg_sum) * pa;
+        pixels[p + 2] = ((b_sum * mul_sum) >> shg_sum) * pa;
+      } else {
+        pixels[p] = pixels[p + 1] = pixels[p + 2] = 0;
+      }
+
+      r_sum -= r_out_sum;
+      g_sum -= g_out_sum;
+      b_sum -= b_out_sum;
+      a_sum -= a_out_sum;
+
+      r_out_sum -= stackIn.r;
+      g_out_sum -= stackIn.g;
+      b_out_sum -= stackIn.b;
+      a_out_sum -= stackIn.a;
+
+      p = (x + (((p = y + radiusPlus1) < heightMinus1 ? p : heightMinus1) * width)) << 2;
+
+      r_sum += (r_in_sum += (stackIn.r = pixels[p]));
+      g_sum += (g_in_sum += (stackIn.g = pixels[p + 1]));
+      b_sum += (b_in_sum += (stackIn.b = pixels[p + 2]));
+      a_sum += (a_in_sum += (stackIn.a = pixels[p + 3]));
+
+      stackIn = stackIn.next;
+
+      r_out_sum += (pr = stackOut.r);
+      g_out_sum += (pg = stackOut.g);
+      b_out_sum += (pb = stackOut.b);
+      a_out_sum += (pa = stackOut.a);
+
+      r_in_sum -= pr;
+      g_in_sum -= pg;
+      b_in_sum -= pb;
+      a_in_sum -= pa;
+
+      stackOut = stackOut.next;
+
+      yi += width;
+    }
+  }
+
+  context.putImageData(imageData, top_x, top_y);
+
+}
+
+function BlurStack() {
+  this.r = 0;
+  this.g = 0;
+  this.b = 0;
+  this.a = 0;
+  this.next = null;
+}


### PR DESCRIPTION
The following features have been added to the Asset Studio and have been tested in Chrome and Firefox on Windows and Linux Mint:
- Elevation option for the foreground image (toggle on/off, can be used in conjunction with effects) 
- Changing the intensity of the shadow (opacity) used by elevation, long shadow, and score effects (slider)
- Change from linear long shadow gradient to a radial effect from the upper left corner(it is more computation intensive, and I did not run any tests to see how much longer it took, but it ran on Chrome and Firefox with no observable time difference)

The elevation effect was achieved using a Gaussian Blur on a black/alpha version of the foreground image. I used the fast open-source StackBlur algorithm (http://www.quasimondo.com/StackBlurForCanvas/StackBlurDemo.html) written in JavaScript by Mario Klingemann and modified for usage within this app. The blur is set to a ~3dp radius. Additionally, the shadow slider defaults to 20% opacity (recommended material design opacity) and can be adjusted from RGBA values [0,0,0,0] to [0,0,0,0,100] in steps of 10. It didn't seem currently necessary to allow for any darker of a shadow than an alpha value of 100.

Below is an example of an icon created using the elevation and long shadow effects with an alpha value of 70, compared with the same icon created using the current asset studio with an alpha value of ~30 and no elevation:

**Original Example**
![Original](https://cloud.githubusercontent.com/assets/1966779/5731892/2cb7dbc6-9b57-11e4-9d9b-e440ae9ceb96.png) 

**New Effects Example**
![New Effects](https://cloud.githubusercontent.com/assets/1966779/5731861/bb6f1ff6-9b56-11e4-8025-e22a7c4c49c6.png)
