### PR TITLE
Add xxxhdpi support

### DIFF
--- a/src/html/icons-actionbar.html
+++ b/src/html/icons-actionbar.html
@@ -81,7 +81,7 @@
       var group = studio.ui.createImageOutputGroup({
         container: $('#outputs')
       });
-      for (var density in {'xxhdpi':1, 'xhdpi':1, 'hdpi':1, 'mdpi':1})
+      for (var density in {'xxxhdpi':1, 'xxhdpi':1, 'xhdpi':1, 'hdpi':1, 'mdpi':1})
         studio.ui.createImageOutputSlot({
           container: group,
           id: 'out-icon-' + density,
@@ -116,7 +116,7 @@
         var srcSize = { w: srcCtx.canvas.width, h: srcCtx.canvas.height };
         var srcRect = { x: 0, y: 0, w: srcSize.w, h: srcSize.h };
 
-        for (var density in {'xxhdpi':1, 'xhdpi':1, 'hdpi':1, 'mdpi':1}) {
+        for (var density in {'xxxhdpi':1, 'xxhdpi':1, 'xhdpi':1, 'hdpi':1, 'mdpi':1}) {
           var mult = studio.util.getMultBaseMdpi(density);
           var iconSize = studio.util.multRound(
               PARAM_RESOURCES['iconSize'], mult);
@@ -191,7 +191,7 @@
           new studio.forms.ImageField('source', {
             title: 'Source',
             helpText: 'Must be transparent',
-            maxFinalSize: { w: 72, h: 72 }, // max render size, for SVGs
+            maxFinalSize: { w: 128, h: 128 }, // max render size, for SVGs
             defaultValueTrim: 1
           }),
           (nameField = new studio.forms.TextField('name', {

--- a/src/html/icons-generic.html
+++ b/src/html/icons-generic.html
@@ -81,7 +81,7 @@
       var group = studio.ui.createImageOutputGroup({
         container: $('#outputs')
       });
-      for (var density in {'xxhdpi':1, 'xhdpi':1, 'hdpi':1, 'mdpi':1})
+      for (var density in {'xxxhdpi':1, 'xxhdpi':1, 'xhdpi':1, 'hdpi':1, 'mdpi':1})
         studio.ui.createImageOutputSlot({
           container: group,
           id: 'out-icon-' + density,
@@ -110,7 +110,7 @@
         var srcSize = { w: srcCtx.canvas.width, h: srcCtx.canvas.height };
         var srcRect = { x: 0, y: 0, w: srcSize.w, h: srcSize.h };
 
-        for (var density in {'xxhdpi':1, 'xhdpi':1, 'hdpi':1, 'mdpi':1}) {
+        for (var density in {'xxxhdpi':1, 'xxhdpi':1, 'xhdpi':1, 'hdpi':1, 'mdpi':1}) {
           var opticalSize = values['size'];
           var padding = values['padding'];
           var totalSize = opticalSize + padding * 2;

--- a/src/html/icons-notification.html
+++ b/src/html/icons-notification.html
@@ -86,7 +86,7 @@
           dark: (version == '11')
         });
 
-        for (var density in {'xxhdpi':1, 'xhdpi':1, 'hdpi':1, 'mdpi':1})
+        for (var density in {'xxxhdpi':1, 'xxhdpi':1, 'xhdpi':1, 'hdpi':1, 'mdpi':1})
           studio.ui.createImageOutputSlot({
             container: group,
             id: 'out-icon-' + version + '-' + density,
@@ -122,7 +122,7 @@
         var srcRect = { x: 0, y: 0, w: srcSize.w, h: srcSize.h };
 
         for (var version in {'X':1, '11':1}) {
-          for (var density in {'xxhdpi':1, 'xhdpi':1, 'hdpi':1, 'mdpi':1}) {
+          for (var density in {'xxxhdpi':1, 'xxhdpi':1, 'xhdpi':1, 'hdpi':1, 'mdpi':1}) {
             var versionStr = (version == 'X') ? '' : ('-v' + version);
 
             var mult = studio.util.getMultBaseMdpi(density);

--- a/src/html/nine-patches.html
+++ b/src/html/nine-patches.html
@@ -368,7 +368,7 @@
     // Set up zipper and image output slots
     var zipper = studio.zip.createDownloadifyZipButton($('#zip-button-stub'));
     var group = studio.ui.createImageOutputGroup({ container: $('#outputs') });
-    for (var density in {'xxhdpi':1, 'xhdpi':1, 'hdpi':1, 'mdpi':1})
+    for (var density in {'xxxhdpi':1, 'xxhdpi':1, 'xhdpi':1, 'hdpi':1, 'mdpi':1})
       studio.ui.createImageOutputSlot({
         container: group,
         id: 'out-patch-' + density,
@@ -1431,9 +1431,10 @@
       zipper.clear();
       zipper.setZipFilename(resourceName + '.9.zip');
 
-      for (var densityStr in {'xxhdpi':1, 'xhdpi':1, 'hdpi':1, 'mdpi':1}) {
+      for (var densityStr in {'xxxhdpi':1, 'xxhdpi':1, 'xhdpi':1, 'hdpi':1, 'mdpi':1}) {
         var density;
         switch (densityStr) {
+          case 'xxxhdpi': density = 640; break;
           case 'xxhdpi': density = 480; break;
           case  'xhdpi': density = 320; break;
           case   'hdpi': density = 240; break;
@@ -1561,7 +1562,8 @@
             { id: '160', title:   'mdpi<br><small>(160)</small>' },
             { id: '240', title:   'hdpi<br><small>(240)</small>' },
             { id: '320', title:  'xhdpi<br><small>(320)</small>' },
-            { id: '480', title: 'xxhdpi<br><small>(480)</small>' }
+            { id: '480', title: 'xxhdpi<br><small>(480)</small>' },
+            { id: '640', title: 'xxxhdpi<br><small>(640)</small>' }
           ],
           defaultValue: '320'
         }),


### PR DESCRIPTION
Added XXXHDPI support per requests in #14 #24 #42 #44

Android Studio 1.1 seems to flag lint warnings if you are not including XXXHDPI assets. By updating AndroidAssetStudio, the developer at least has the option of including a generated XXXHDPI version in their application. 

See demo at http://joerogers.github.io/AndroidAssetStudio/