### PR TITLE
Update icons-launcher.html to generate full size launcher icons

### DIFF
--- a/src/html/icons-launcher.html
+++ b/src/html/icons-launcher.html
@@ -133,41 +133,41 @@
         'hdpi-iconSize': { w:  72, h:  72 },
         'mdpi-iconSize': { w:  48, h:  48 },
 
-         'web-bevel-targetRect': { x: 32, y: 32, w: 448, h: 448 },
-        'hdpi-bevel-targetRect': { x:  4, y:  4, w:  64, h:  64 },
-        'mdpi-bevel-targetRect': { x:  3, y:  3, w:  42, h:  42 },
+         'web-bevel-targetRect': { x: 0, y: 0, w: 512, h: 512 },
+        'hdpi-bevel-targetRect': { x:  0, y:  0, w:  72, h:  72 },
+        'mdpi-bevel-targetRect': { x:  0, y:  0, w:  48, h:  48 },
 
-         'web-none-targetRect': { x: 32, y: 32, w: 448, h: 448 },
-        'hdpi-none-targetRect': { x:  4, y:  4, w:  64, h:  64 },
-        'mdpi-none-targetRect': { x:  3, y:  3, w:  42, h:  42 },
+         'web-none-targetRect': { x: 0, y: 0, w: 512, h: 512 },
+        'hdpi-none-targetRect': { x:  0, y:  0, w:  72, h:  72 },
+        'mdpi-none-targetRect': { x:  0, y:  0, w:  48, h:  48 },
 
-         'web-circle-targetRect': { x: 21, y: 21, w: 470, h: 470 },
-        'hdpi-circle-targetRect': { x:  3, y:  3, w:  66, h:  66 },
-        'mdpi-circle-targetRect': { x:  2, y:  2, w:  44, h:  44 },
+         'web-circle-targetRect': { x: 0, y: 0, w: 512, h: 512 },
+        'hdpi-circle-targetRect': { x:  0, y:  0, w:  72, h:  72 },
+        'mdpi-circle-targetRect': { x:  0, y:  0, w:  48, h:  48 },
 
-         'web-square-targetRect': { x: 53, y: 53, w: 406, h: 406 },
-        'hdpi-square-targetRect': { x:  7, y:  7, w:  57, h:  57 },
-        'mdpi-square-targetRect': { x:  5, y:  5, w:  38, h:  38 },
+         'web-square-targetRect': { x: 0, y: 0, w: 512, h: 512 },
+        'hdpi-square-targetRect': { x:  0, y:  0, w:  72, h:  72 },
+        'mdpi-square-targetRect': { x:  0, y:  0, w:  48, h:  48 },
 
-         'web-vrect-targetRect': { x: 85, y: 21, w: 342, h: 470 },
-        'hdpi-vrect-targetRect': { x: 12, y:  3, w:  48, h:  66 },
-        'mdpi-vrect-targetRect': { x:  8, y:  2, w:  32, h:  44 },
+         'web-vrect-targetRect': { x: 0, y: 0, w: 512, h: 512 },
+        'hdpi-vrect-targetRect': { x: 0, y:  0, w:  72, h:  72 },
+        'mdpi-vrect-targetRect': { x:  0, y:  0, w:  48, h:  48 },
 
-         'web-hrect-targetRect': { x: 21, y: 85, w: 470, h: 342 },
-        'hdpi-hrect-targetRect': { x:  3, y: 12, w:  66, h:  48 },
-        'mdpi-hrect-targetRect': { x:  2, y:  8, w:  44, h:  32 },
+         'web-hrect-targetRect': { x: 0, y: 0, w: 512, h: 512 },
+        'hdpi-hrect-targetRect': { x:  0, y: 0, w:  72, h:  72 },
+        'mdpi-hrect-targetRect': { x:  0, y:  0, w:  48, h:  48 },
 
-        'web-square-dogear-targetRect': { x: 53, y: 149, w: 406, h: 312 },
-       'hdpi-square-dogear-targetRect': { x:  7, y:  21, w:  57, h:  43 },
-       'mdpi-square-dogear-targetRect': { x:  5, y:  14, w:  38, h:  29 },
+        'web-square-dogear-targetRect': { x: 0, y: 0, w: 512, h: 512 },
+       'hdpi-square-dogear-targetRect': { x:  0, y:  0, w:  72, h:  72 },
+       'mdpi-square-dogear-targetRect': { x:  0, y:  0, w:  48, h:  48 },
 
-        'web-vrect-dogear-targetRect': { x: 85, y: 117, w: 342, h: 374 },
-       'hdpi-vrect-dogear-targetRect': { x: 12, y:  17, w:  48, h:  52 },
-       'mdpi-vrect-dogear-targetRect': { x:  8, y:  11, w:  32, h:  35 },
+        'web-vrect-dogear-targetRect': { x: 0, y: 0, w: 512, h: 512 },
+       'hdpi-vrect-dogear-targetRect': { x: 0, y:  0, w:  72, h:  72 },
+       'mdpi-vrect-dogear-targetRect': { x:  0, y:  0, w:  48, h:  48 },
 
-        'web-hrect-dogear-targetRect': { x: 21, y: 85, w: 374, h: 342 },
-       'hdpi-hrect-dogear-targetRect': { x:  3, y: 12, w:  52, h:  48 },
-       'mdpi-hrect-dogear-targetRect': { x:  2, y:  8, w:  35, h:  32 }
+        'web-hrect-dogear-targetRect': { x: 0, y: 0, w: 512, h: 512 },
+       'hdpi-hrect-dogear-targetRect': { x:  0, y: 0, w:  72, h:  72 },
+       'mdpi-hrect-dogear-targetRect': { x:  0, y:  0, w:  48, h:  48 }
       };
 
       /**


### PR DESCRIPTION
Removes all padding around generated launcher icons.

See http://stackoverflow.com/questions/21266493/android-asset-studio-adds-extra-space-when-i-upload-my-png-icons-but-doesnt