### PR TITLE
generate assets with multi-line text

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Currently available asset generators are for:
 - Generic square icons
 - Simple nine-patches
 
+Now supporting generating icons with multi-line text.
+
 ## Building the tool
 
 To build, ensure you have `node` and `npm` installed, and run:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Currently available asset generators are for:
 - Generic square icons
 - Simple nine-patches
 
-Now supporting generating icons with multi-line text.
+Now supporting assests with multi-line text.
 
 ## Building the tool
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Currently available asset generators are for:
 - Generic square icons
 - Simple nine-patches
 
-Now supporting assests with multi-line text.
+Now supporting assets with multi-line text.
 
 ## Building the tool
 

--- a/app/scripts/studio/forms/ImageField.js
+++ b/app/scripts/studio/forms/ImageField.js
@@ -179,7 +179,7 @@ export class ImageField extends Field {
         container: textParamsEl,
         fields: [
           new TextField('text', {
-            title: 'Text',
+            title: 'Text - use ^ for multi-line',
           }),
           (fontFamilyField = new EnumField('font', {
             title: 'Font',
@@ -535,21 +535,24 @@ export class ImageField extends Field {
           var size = { w: 6144, h: 1536 };
           var ctx = imagelib.Drawing.context(size);
           var text = this.textParams_.text || '';
-          var lines = text.split("\n");
+          var lines = text.split("^");
           var numberOfLines = lines.length;
-          var lineHeight = Math.ceil(size.h / numberOfLines);
-          var textHeight = Math.ceil(lineHeighth * 0.75);
-          var linePositionHeight = lineHeight;
+          var lineHeight = Math.floor(size.h / numberOfLines);
+          var textHeight = Math.floor(lineHeight * 0.75);
+          var linePositionHeight = lineHeight*.8;
+		  var textWidth;
 
           ctx.fillStyle = '#000';          
           ctx.textBaseline = 'alphabetic';          
           ctx.font = `bold ${textHeight}px/${size.h}px ${this.textParams_.fontStack}`;
+		  console.log(ctx.font);
           for (var i = 0; i < numberOfLines; ++i) {
             ctx.fillText(' ' + lines[i] + ' ', 0, linePositionHeight);
             linePositionHeight += lineHeight;
+			 textWidth = Math.max(ctx.measureText(' ' + lines[i] + ' ').width, textWidth);		 
           }
-          
-          size.w = Math.ceil(Math.min(ctx.measureText(text).width, size.w) || size.w);
+          size.w = Math.ceil(Math.min(textWidth, size.w) || size.w);
+	
           resolve({ctx, size});
           break;
 

--- a/app/scripts/studio/forms/ImageField.js
+++ b/app/scripts/studio/forms/ImageField.js
@@ -533,17 +533,23 @@ export class ImageField extends Field {
 
         case 'text':
           var size = { w: 6144, h: 1536 };
-          var textHeight = size.h * 0.75;
           var ctx = imagelib.Drawing.context(size);
           var text = this.textParams_.text || '';
-          text = ' ' + text + ' ';
+          var lines = text.split("\n");
+          var numberOfLines = lines.length;
+          var lineHeight = Math.ceil(size.h / numberOfLines);
+          var textHeight = Math.ceil(lineHeighth * 0.75);
+          var linePositionHeight = lineHeight;
 
-          ctx.fillStyle = '#000';
+          ctx.fillStyle = '#000';          
+          ctx.textBaseline = 'alphabetic';          
           ctx.font = `bold ${textHeight}px/${size.h}px ${this.textParams_.fontStack}`;
-          ctx.textBaseline = 'alphabetic';
-          ctx.fillText(text, 0, textHeight);
+          for (var i = 0; i < numberOfLines; ++i) {
+            ctx.fillText(' ' + lines[i] + ' ', 0, linePositionHeight);
+            linePositionHeight += lineHeight;
+          }
+          
           size.w = Math.ceil(Math.min(ctx.measureText(text).width, size.w) || size.w);
-
           resolve({ctx, size});
           break;
 


### PR DESCRIPTION
Added functionality to create assets with multi-line text. The character ^ in the text field will start a new line of text on the asset.