### PR TITLE
Change the square size and padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Android Asset Studio
 ====================
 
-**[Open the Android Asset Studio](https://romannurik.github.io/AndroidAssetStudio/)**
+**[Open the Android Asset Studio](https://jekos.github.io/AndroidAssetStudio)**
 
 **[See the older version](https://romannurik.github.io/AndroidAssetStudio/older-version/) if you're having trouble with the new version**
 

--- a/app/scripts/pages/LauncherIconGenerator.js
+++ b/app/scripts/pages/LauncherIconGenerator.js
@@ -23,7 +23,7 @@ const ICON_SIZE = { w: 48, h: 48 };
 const TARGET_RECTS_BY_SHAPE = {
   none: { x:  3, y:  3, w:  42, h:  42 },
   circle: { x:  2, y:  2, w:  44, h:  44 },
-  square: { x:  5, y:  5, w:  38, h:  38 },
+  square: { x:  2, y:  2, w:  44, h:  44 },
   vrect: { x:  8, y:  2, w:  32, h:  44 },
   hrect: { x:  2, y:  8, w:  44, h:  32 },
 };


### PR DESCRIPTION
Change the square: { x:  5, y:  5, w:  38, h:  38 }, to square: { x:  2, y:  2, w:  44, h:  44 }. So icon won't be smaller than other icons in the phone.

Many people have problem showing their icon smaller than other icons e.g Google Maps . So I change the padding and the size for the square icon.

Here is an example about this problem: https://stackoverflow.com/questions/34904069/laucher-icon-generated-from-android-asset-studio-is-small/43567171#43567171

