### PR TITLE
Added subfolder selector to Generic Icon Generator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ To build, ensure you have `node` and `npm` installed, and run:
 
     $ npm install
 
+Aparentemente, puede generarse un error
+	```Error: Cannot find module 'js-yaml'```
+
+Solve it installing
+
+	$ npm install js-yaml
+
 Once dependencies are installed, run with `gulp`:
 
     $ gulp serve

--- a/app/scripts/pages/GenericIconGenerator.js
+++ b/app/scripts/pages/GenericIconGenerator.js
@@ -68,6 +68,17 @@ export class GenericIconGenerator extends BaseGenerator {
           defaultValue: 'rgba(0, 0, 0, 0.54)',
           alpha: true
         }),
+		new studio.EnumField('subfolder',{
+			id: 'drawable', title: 'Subfolder', defaultValue: 'drawable',
+			options: [
+				{
+					id: 'drawable', 'title': 'Drawable'
+				},
+				{
+					id: 'mipmap', 'title': 'Mipmap'
+				}
+			]
+		}),
         (nameField = new studio.TextField('name', {
           title: 'Name',
           helpText: 'Used when generating ZIP files as the resource name.',
@@ -118,9 +129,8 @@ export class GenericIconGenerator extends BaseGenerator {
       } else {
         outCtx.drawImage(tmpCtx.canvas, 0, 0);
       }
-
       this.zipper.add({
-        name: `res/drawable-${density}/${values.name}.png`,
+        name: `res/${values.subfolder}-${density}/${values.name}.png`,
         canvas: outCtx.canvas
       });
 


### PR DESCRIPTION
Actually, Android Studio work with Drawable SVG files. The IMG files are saved as MipMap values. I did add a selector for subfolder selection, [mipmap, drawable] in the form for Generic Icon Generation