### PR TITLE
Sanitise empty filenames

### DIFF
--- a/app/pages/action-bar-icon-generator.js
+++ b/app/pages/action-bar-icon-generator.js
@@ -100,6 +100,7 @@ export class ActionBarIconGenerator extends BaseGenerator {
 
   regenerate() {
     let values = this.form.getValues();
+    values.name = values.name || 'ic_action';
 
     this.zipper.clear();
     this.zipper.setZipFilename(`${values.name}.zip`);

--- a/app/pages/app-shortcut-icon-generator.js
+++ b/app/pages/app-shortcut-icon-generator.js
@@ -79,6 +79,7 @@ export class AppShortcutIconGenerator extends BaseGenerator {
 
   regenerate() {
     let values = this.form.getValues();
+    values.name = values.name || 'ic_shortcut';
 
     this.zipper.clear();
     this.zipper.setZipFilename(`${values.name}.zip`);

--- a/app/pages/generic-icon-generator.js
+++ b/app/pages/generic-icon-generator.js
@@ -77,6 +77,7 @@ export class GenericIconGenerator extends BaseGenerator {
 
   regenerate() {
     let values = this.form.getValues();
+    values.name = values.name || 'icon';
 
     this.zipper.clear();
     this.zipper.setZipFilename(`${values.name}.zip`);

--- a/app/pages/launcher-icon-generator.js
+++ b/app/pages/launcher-icon-generator.js
@@ -133,6 +133,7 @@ export class LauncherIconGenerator extends BaseGenerator {
 
   regenerate() {
     let values = this.form.getValues();
+    values.name = values.name || 'ic_launcher';
 
     this.zipper.clear();
     this.zipper.setZipFilename(`${values.name}.zip`);

--- a/app/pages/ninepatch/nine-patch-generator.js
+++ b/app/pages/ninepatch/nine-patch-generator.js
@@ -135,6 +135,7 @@ export class NinePatchGenerator extends BaseGenerator {
     }
 
     let values = this.form.getValues();
+    values.name = values.name || 'outline';
 
     this.zipper.clear();
     this.zipper.setZipFilename(`${values.name}.9.zip`);

--- a/app/pages/notification-icon-generator.js
+++ b/app/pages/notification-icon-generator.js
@@ -63,6 +63,7 @@ export class NotificationIconGenerator extends BaseGenerator {
 
   regenerate() {
     let values = this.form.getValues();
+    values.name = values.name || 'ic_stat';
 
     this.zipper.clear();
     this.zipper.setZipFilename(`${values.name}.zip`);


### PR DESCRIPTION
Otherwise the produced files will be named '.png', i.e. be hidden on Linux and macOS.