### PR TITLE
Missing natives

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gulp-util": "^3.0.8",
     "import-glob": "^1.5.0",
     "merge-stream": "^1.0.1",
+    "natives": "^1.1.6",
     "pretty-bytes": "^5.1.0",
     "run-sequence": "^2.2.1",
     "webpack": "^4.16.1",


### PR DESCRIPTION
I've done a clean installation on Debian and after running with gulp serve, got the following issue:

const types = internalBinding('types');
                      ^
ReferenceError: internalBinding is not defined

Problem fixed after adding "natives" to "devDependencies" of package.json